### PR TITLE
For clarity, rename createStamp to reactStamp

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ This library is the result of wondering about what other ways a React component 
 react-stamp has an API similar to `React.createClass`. The factory accepts two parameters, the React library and a description object.
 
 ```js
-createStamp(React, {
+reactStamp(React, {
   init() {},
   state: {},
   statics: {},
@@ -52,14 +52,14 @@ export default {
 __component.jsx__
 
 ```js
-import createClass from 'react-stamp';
+import reactStamp from 'react-stamp';
 import { cache } from 'react-stamp/utils';
 
 const id = cache.uniqueId();
 
 export default React => {
   return cache.find(id) || cache.save(
-    createStamp(React, {
+    reactStamp(React, {
       state: {
         comp: false,
         mixin1: false,
@@ -129,7 +129,7 @@ You may have noticed several interesting behaviors.
 
  This is shorthand syntax for:
  ```js
- createStamp(null, {
+ reactStamp(null, {
    // stuff
  });
  ```

--- a/src/index.js
+++ b/src/index.js
@@ -16,7 +16,7 @@ import {
  *
  * @return {Object} A stamp.
  */
-export default function createStamp(React, desc = {}) {
+export default function reactStamp(React, desc = {}) {
   const specDesc = parseDesc(desc);
   const { methods, initializers } = getReactDescriptor(React && React.Component);
 

--- a/src/utils/compose.js
+++ b/src/utils/compose.js
@@ -2,7 +2,7 @@ import assign from 'lodash/object/assign';
 import forEach from 'lodash/collection/forEach';
 import merge from 'lodash/object/merge';
 
-import createStamp from '..';
+import reactStamp from '..';
 import {
   initDescriptor,
   parseDesc,
@@ -54,5 +54,5 @@ export default function compose(...args) {
     merge(compDesc.configuration, desc.configuration);
   });
 
-  return createStamp(null, compDesc);
+  return reactStamp(null, compDesc);
 }

--- a/src/utils/decorator.js
+++ b/src/utils/decorator.js
@@ -1,7 +1,7 @@
 import assign from 'lodash/object/assign';
 import merge from 'lodash/object/merge';
 
-import createStamp from '..';
+import reactStamp from '..';
 
 /**
  * Get the non-enum properties of an object.
@@ -63,5 +63,5 @@ export default function stamp(Class) {
     getNonEnum(Class.prototype)
   )
 
-  return createStamp(null, desc);
+  return reactStamp(null, desc);
 }

--- a/test/advanced.js
+++ b/test/advanced.js
@@ -2,7 +2,7 @@ import keys from 'lodash/object/keys';
 import React from 'react';
 import test from 'tape';
 
-import createStamp from '../src';
+import reactStamp from '../src';
 import { cache, stamp } from '../src/utils';
 
 test('stamp decorator', (t) => {
@@ -59,7 +59,7 @@ test('stamp factory using `cacheStamp`', (t) => {
 
   const stampFactory1 = React => {
     return cache.find(id1) || cache.save(
-      createStamp(React, {
+      reactStamp(React, {
         displayName: 'Component',
       }), id1
     );
@@ -67,7 +67,7 @@ test('stamp factory using `cacheStamp`', (t) => {
 
   const stampFactory2 = React => {
     return cache.find(id2) || cache.save(
-      createStamp(React)
+      reactStamp(React)
     );
   };
 

--- a/test/basics.js
+++ b/test/basics.js
@@ -1,34 +1,23 @@
 import React from 'react/addons';
 import test from 'tape';
 
-import createStamp from '../src';
+import reactStamp from '../src';
 
 const TestUtils = React.addons.TestUtils;
 
-test('createStamp()', (t) => {
+test('reactStamp()', (t) => {
   t.plan(1);
 
   t.ok(
-    createStamp().compose,
+    reactStamp().compose,
     'should return a stamp'
   );
 });
 
-test('createStamp(React, props)', (t) => {
+test('reactStamp(React, props)', (t) => {
   t.plan(1);
 
-  const stamp = createStamp(React, {});
-
-  t.ok(
-    stamp.compose,
-    'should return a stamp'
-  );
-});
-
-test('createStamp(React)', (t) => {
-  t.plan(1);
-
-  const stamp = createStamp(React);
+  const stamp = reactStamp(React, {});
 
   t.ok(
     stamp.compose,
@@ -36,10 +25,10 @@ test('createStamp(React)', (t) => {
   );
 });
 
-test('createStamp(null, props)', (t) => {
+test('reactStamp(React)', (t) => {
   t.plan(1);
 
-  const stamp = createStamp(null, {});
+  const stamp = reactStamp(React);
 
   t.ok(
     stamp.compose,
@@ -47,10 +36,21 @@ test('createStamp(null, props)', (t) => {
   );
 });
 
-test('createStamp(React, { render() })()', (t) => {
+test('reactStamp(null, props)', (t) => {
   t.plan(1);
 
-  const stamp = createStamp(React, {
+  const stamp = reactStamp(null, {});
+
+  t.ok(
+    stamp.compose,
+    'should return a stamp'
+  );
+});
+
+test('reactStamp(React, { render() })()', (t) => {
+  t.plan(1);
+
+  const stamp = reactStamp(React, {
     render() {},
   });
 
@@ -60,11 +60,11 @@ test('createStamp(React, { render() })()', (t) => {
   );
 });
 
-test('createStamp(React, props).compose', (t) => {
+test('reactStamp(React, props).compose', (t) => {
   t.plan(1);
 
   t.equal(
-    typeof createStamp(React).compose, 'function',
+    typeof reactStamp(React).compose, 'function',
     'should be a function'
   );
 });

--- a/test/compose.js
+++ b/test/compose.js
@@ -2,19 +2,19 @@ import keys from 'lodash/object/keys';
 import React from 'react';
 import test from 'tape';
 
-import createStamp from '../src';
+import reactStamp from '../src';
 import { compose } from '../src/utils';
 
-test('createStamp(React, props).compose(stamp2)', (t) => {
+test('reactStamp(React, props).compose(stamp2)', (t) => {
   t.plan(1);
 
-  const mixin = createStamp(null, {
+  const mixin = reactStamp(null, {
     method() {
       return 'mixin';
     },
   });
 
-  const stamp = createStamp(React).compose(mixin);
+  const stamp = reactStamp(React).compose(mixin);
 
   t.equal(
     stamp().method(), 'mixin',
@@ -22,7 +22,7 @@ test('createStamp(React, props).compose(stamp2)', (t) => {
   );
 });
 
-test('createStamp(React, props).compose(pojo)', (t) => {
+test('reactStamp(React, props).compose(pojo)', (t) => {
   t.plan(1);
 
   const mixin = {
@@ -31,7 +31,7 @@ test('createStamp(React, props).compose(pojo)', (t) => {
     },
   };
 
-  const stamp = createStamp(React).compose(mixin);
+  const stamp = reactStamp(React).compose(mixin);
 
   t.equal(
     stamp().method(), 'mixin',
@@ -39,16 +39,16 @@ test('createStamp(React, props).compose(pojo)', (t) => {
   );
 });
 
-test('createStamp(React, props).compose(stamp2, stamp3)', (t) => {
+test('reactStamp(React, props).compose(stamp2, stamp3)', (t) => {
   t.plan(2);
 
-  const mixin1 = createStamp(null, {
+  const mixin1 = reactStamp(null, {
     method() {
       return this.state;
     },
   });
 
-  const mixin2 = createStamp(null, {
+  const mixin2 = reactStamp(null, {
     statics: {
       util() {
         return 'static';
@@ -56,7 +56,7 @@ test('createStamp(React, props).compose(stamp2, stamp3)', (t) => {
     },
   });
 
-  const stamp = createStamp(React, {
+  const stamp = reactStamp(React, {
     state: {
       foo: '',
     },
@@ -76,13 +76,13 @@ test('createStamp(React, props).compose(stamp2, stamp3)', (t) => {
 test('compose(stamp2, stamp1)', (t) => {
   t.plan(1);
 
-  const mixin = createStamp(null, {
+  const mixin = reactStamp(null, {
     method() {
       return 'mixin';
     },
   });
 
-  const stamp = createStamp(React);
+  const stamp = reactStamp(React);
 
   t.equal(
     compose(mixin, stamp)().method(), 'mixin',
@@ -93,19 +93,19 @@ test('compose(stamp2, stamp1)', (t) => {
 test('stamps composed of stamps with state', (t) => {
   t.plan(2);
 
-  const mixin = createStamp(null, {
+  const mixin = reactStamp(null, {
     state: {
       foo: ' ',
     },
   });
 
-  const stamp = createStamp(React, {
+  const stamp = reactStamp(React, {
     state: {
       bar: ' ',
     },
   }).compose(mixin);
 
-  const failStamp = createStamp(React, {
+  const failStamp = reactStamp(React, {
     state: {
       foo: ' ',
     },
@@ -125,7 +125,7 @@ test('stamps composed of stamps with state', (t) => {
 test('stamps composed of stamps with React statics', (t) => {
   t.plan(8);
 
-  const mixin = createStamp(null, {
+  const mixin = reactStamp(null, {
     contextTypes: {
       foo: React.PropTypes.string,
     },
@@ -140,7 +140,7 @@ test('stamps composed of stamps with React statics', (t) => {
     },
   });
 
-  const stamp = createStamp(React, {
+  const stamp = reactStamp(React, {
     contextTypes: {
       bar: React.PropTypes.string,
     },
@@ -155,25 +155,25 @@ test('stamps composed of stamps with React statics', (t) => {
     },
   }).compose(mixin);
 
-  const failStamp1 = createStamp(React, {
+  const failStamp1 = reactStamp(React, {
     propTypes: {
       foo: React.PropTypes.string,
     },
   });
 
-  const failStamp2 = createStamp(React, {
+  const failStamp2 = reactStamp(React, {
     defaultProps: {
       foo: 'foo',
     },
   });
 
-  const okStamp1 = createStamp(React, {
+  const okStamp1 = reactStamp(React, {
     contextTypes: {
       foo: React.PropTypes.string,
     },
   });
 
-  const okStamp2 = createStamp(React, {
+  const okStamp2 = reactStamp(React, {
     childContextTypes: {
       foo: React.PropTypes.string,
     },
@@ -223,7 +223,7 @@ test('stamps composed of stamps with React statics', (t) => {
 test('stamps composed of stamps with non-React statics', (t) => {
   t.plan(2);
 
-  const mixin = createStamp(null, {
+  const mixin = reactStamp(null, {
     statics: {
       obj: {
         foo: 'foo',
@@ -235,7 +235,7 @@ test('stamps composed of stamps with non-React statics', (t) => {
     },
   });
 
-  const stamp = createStamp(React, {
+  const stamp = reactStamp(React, {
     statics: {
       obj: {
         bar: '',
@@ -260,7 +260,7 @@ test('stamps composed of stamps with non-React statics', (t) => {
 test('stamps composed of stamps with mixable methods', (t) => {
   t.plan(2);
 
-  const mixin1 = createStamp(null, {
+  const mixin1 = reactStamp(null, {
     getChildContext() {
       return {
         bar: '',
@@ -272,13 +272,13 @@ test('stamps composed of stamps with mixable methods', (t) => {
     },
   });
 
-  const mixin2 = createStamp(null, {
+  const mixin2 = reactStamp(null, {
     componentDidMount() {
       this.state.mixin2 = true;
     },
   });
 
-  const stamp = createStamp(React, {
+  const stamp = reactStamp(React, {
     state: {
       stamp: false,
       mixin1: false,
@@ -313,11 +313,11 @@ test('stamps composed of stamps with mixable methods', (t) => {
 test('stamps composed of stamps with non-mixable methods', (t) => {
   t.plan(1);
 
-  const mixin = createStamp(null, {
+  const mixin = reactStamp(null, {
     render() {},
   });
 
-  const stamp = createStamp(React, {
+  const stamp = reactStamp(React, {
     render() {},
   });
 

--- a/test/methods.js
+++ b/test/methods.js
@@ -1,12 +1,12 @@
 import React from 'react';
 import test from 'tape';
 
-import createStamp from '../src';
+import reactStamp from '../src';
 
-test('createStamp(React, { method() {} })()', (t) => {
+test('reactStamp(React, { method() {} })()', (t) => {
   t.plan(1);
 
-  const stamp = createStamp(React, {
+  const stamp = reactStamp(React, {
     render() {},
   });
 

--- a/test/state.js
+++ b/test/state.js
@@ -2,12 +2,12 @@ import has from 'lodash/object/has';
 import React from 'react';
 import test from 'tape';
 
-import createStamp from '../src';
+import reactStamp from '../src';
 
-test('createStamp(React, { state: obj })()', (t) => {
+test('reactStamp(React, { state: obj })()', (t) => {
   t.plan(1);
 
-  const stamp = createStamp(React, {
+  const stamp = reactStamp(React, {
     state: {
       foo: '',
     },
@@ -19,10 +19,10 @@ test('createStamp(React, { state: obj })()', (t) => {
   );
 });
 
-test('createStamp(React, { init() { ... } })()', (t) => {
+test('reactStamp(React, { init() { ... } })()', (t) => {
   t.plan(1);
 
-  const stamp = createStamp(React, {
+  const stamp = reactStamp(React, {
     init() {
       this.state = { foo: '' };
     },

--- a/test/statics.js
+++ b/test/statics.js
@@ -2,12 +2,12 @@ import has from 'lodash/object/has';
 import React from 'react';
 import test from 'tape';
 
-import createStamp from '../src';
+import reactStamp from '../src';
 
-test('createStamp(React, { statics: obj })', (t) => {
+test('reactStamp(React, { statics: obj })', (t) => {
   t.plan(1);
 
-  const stamp = createStamp(React, {
+  const stamp = reactStamp(React, {
     statics: {
       foo: '',
     },
@@ -19,10 +19,10 @@ test('createStamp(React, { statics: obj })', (t) => {
   );
 });
 
-test('createStamp(React, { displayName: str })', (t) => {
+test('reactStamp(React, { displayName: str })', (t) => {
   t.plan(1);
 
-  const stamp = createStamp(React, {
+  const stamp = reactStamp(React, {
     displayName: 'stamp',
   });
 
@@ -32,10 +32,10 @@ test('createStamp(React, { displayName: str })', (t) => {
   );
 });
 
-test('createStamp(React, { contextTypes: obj })', (t) => {
+test('reactStamp(React, { contextTypes: obj })', (t) => {
   t.plan(1);
 
-  const stamp = createStamp(React, {
+  const stamp = reactStamp(React, {
     contextTypes: {},
   });
 
@@ -45,10 +45,10 @@ test('createStamp(React, { contextTypes: obj })', (t) => {
   );
 });
 
-test('createStamp(React, { childContextTypes: obj })', (t) => {
+test('reactStamp(React, { childContextTypes: obj })', (t) => {
   t.plan(1);
 
-  const stamp = createStamp(React, {
+  const stamp = reactStamp(React, {
     childContextTypes: {},
   });
 
@@ -58,10 +58,10 @@ test('createStamp(React, { childContextTypes: obj })', (t) => {
   );
 });
 
-test('createStamp(React, { propTypes: obj })', (t) => {
+test('reactStamp(React, { propTypes: obj })', (t) => {
   t.plan(1);
 
-  const stamp = createStamp(React, {
+  const stamp = reactStamp(React, {
     propTypes: {},
   });
 
@@ -71,10 +71,10 @@ test('createStamp(React, { propTypes: obj })', (t) => {
   );
 });
 
-test('createStamp(React, { defaultProps: obj })', (t) => {
+test('reactStamp(React, { defaultProps: obj })', (t) => {
   t.plan(1);
 
-  const stamp = createStamp(React, {
+  const stamp = reactStamp(React, {
     defaultProps: {},
   });
 


### PR DESCRIPTION
Renaming just to make it clear that this method is not the same as the `createStamp` method in the stamp spec example implementation.