### PR TITLE
Simplify README example, move factory example to advanced docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,9 +7,9 @@
 
 ## What is this
 
-This library is the result of wondering about what other ways a React component could be represented. [Stamps](https://github.com/stampit-org/stamp-specification) are a cool concept, and more importantly have proven to be a great alternative to `React.createClass` and the ES6 `class` due to their flexibility and use of multiple kinds of prototypal inheritance.
+This library is the result of wondering about what other ways a React component could be represented. [Stamps](https://github.com/stampit-org/stamp-specification) are a cool concept, and more importantly have proven to be a great alternative to `React.createClass` and the ES2015 `class` due to their composability.
 
-react-stamp has an API similar to `React.createClass`. The factory accepts two parameters, the React library and a description object.
+react-stamp provides an API similar to `React.createClass` while being stamp-compatible. The factory accepts two parameters, the React library and a description object.
 
 ```js
 reactStamp(React, {
@@ -27,7 +27,7 @@ reactStamp(React, {
 });
 ```
 
-The best part about [stamps](https://github.com/stampit-org/stamp-specification) is their composability. What this means is that `n` number of stamps can be combined into a new stamp which inherits each passed stamp's behavior. This is perfect for React, since `class` is being pushed as the new norm and does not provide an idiomatic way to use mixins. (classical inheritance :disappointed:). While stamp composability on the surface is a new concept, the conventions used underneath are idiomatic to JavaScript; it is these conventions that provide a limitless way to extend any React component.
+The best part about [stamps](https://github.com/stampit-org/stamp-specification) is their composability. What this means is that `n` number of stamps can be combined into a new stamp which inherits each passed stamp's behavior. This is perfect for React, since `class` is being pushed as the new norm and does not provide an idiomatic way to use mixins. (classical inheritance :disappointed:). While stamps and their composability are a new concept, the conventions used underneath are idiomatic to JavaScript; it is these conventions that provide a multitude of ways to extend React components.
 
 __mixin1.jsx__
 
@@ -52,46 +52,38 @@ export default {
 __component.jsx__
 
 ```js
+import React from 'react';
 import reactStamp from 'react-stamp';
-import { cache } from 'react-stamp/utils';
 
-const id = cache.uniqueId();
+export default reactStamp(React, {
+  state: {
+    comp: false,
+    mixin1: false,
+    mixin2: false,
+  },
 
-export default React => {
-  return cache.find(id) || cache.save(
-    reactStamp(React, {
-      state: {
-        comp: false,
-        mixin1: false,
-        mixin2: false,
-      },
+  _onClick() {
+    return this.state;
+  },
 
-      _onClick() {
-        return this.state;
-      },
+  componentWillMount() {
+    this.state.comp = true;
+  },
 
-      componentWillMount() {
-        this.state.comp = true;
-      },
-
-      render() {
-        return <input type='button' onClick={() => this._onClick()} />;
-      },
-    }), id
-  );
-};
+  render() {
+    return <input type='button' onClick={() => this._onClick()} />;
+  },
+});
 ```
 
 __app.jsx__
 
 ```js
-import React from 'react';
-
-import componentFactory from './component';
+import Component from './component';
 import mixin1 from './mixin1';
 import mixin2 from './mixin2';
 
-const Component = componentFactory(React).compose(mixin1, mixin2);
+const ComposedComp = Component.compose(mixin1, mixin2);
 
 /**
  * Do things
@@ -99,29 +91,12 @@ const Component = componentFactory(React).compose(mixin1, mixin2);
 ```
 
 ```js
-shallowRenderer.render(<Component />);
-const button = shallowRenderer.getRenderOutput();
-
-assert.deepEqual(
-  button.props.onClick(), { comp: true, mixin1: true, mixin2: true },
-  'should return component state with all truthy props'
-);
-  >> ok
+onClick() => { comp: true, mixin1: true, mixin2: true }
 ```
-
-You may have noticed several interesting behaviors.
-
-* component is a factory
-
- This design pattern is optional, but recommended. Component factories are react-stamp's solution for avoiding the often hard to debug problems created by multiple instances of React. Read more about that [here](https://medium.com/@dan_abramov/two-weird-tricks-that-fix-react-7cf9bbdef375). By injecting the React library, we are able to guarantee the version and instance of React that a component will receive.
-
-* caching
-
- This goes hand in hand with designing components as factories. Node.js's internal caching will not work as expected for component factories, react-stamp's cache utility can be used as a replacement.
 
 * no autobinding
 
- Event handlers require explicit binding. No magic. This can be done using `.bind` or through lexical binding with ES6 [arrow functions](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Functions/Arrow_functions) as shown in the example.
+ Event handlers require explicit binding. No magic. This can be done using `.bind` or through lexical binding with ES2015 [arrow functions](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Functions/Arrow_functions) as shown in the example.
 * no `call super`
 
  React methods are wrapped during composition, providing functional inheritance. Sweet.

--- a/docs/advanced.md
+++ b/docs/advanced.md
@@ -1,5 +1,88 @@
 ## Advanced use cases
 
+### Component factory
+
+__mixin1.jsx__
+
+```js
+export default {
+  componentWillMount() {
+    this.state.mixin1 = true;
+  },
+};
+```
+
+__mixin2.jsx__
+
+```js
+export default {
+  componentWillMount() {
+    this.state.mixin2 = true;
+  },
+};
+```
+
+__component.jsx__
+
+```js
+import reactStamp from 'react-stamp';
+import { cache } from 'react-stamp/utils';
+
+const id = cache.uniqueId();
+
+export default React => {
+  return cache.find(id) || cache.save(
+    reactStamp(React, {
+      state: {
+        comp: false,
+        mixin1: false,
+        mixin2: false,
+      },
+
+      _onClick() {
+        return this.state;
+      },
+
+      componentWillMount() {
+        this.state.comp = true;
+      },
+
+      render() {
+        return <input type='button' onClick={() => this._onClick()} />;
+      },
+    }), id
+  );
+};
+```
+
+__app.jsx__
+
+```js
+import React from 'react';
+
+import componentFactory from './component';
+import mixin1 from './mixin1';
+import mixin2 from './mixin2';
+
+const ComposedComp = componentFactory(React).compose(mixin1, mixin2);
+
+/**
+ * Do things
+ */
+```
+
+```js
+onClick() => { comp: true, mixin1: true, mixin2: true }
+```
+
+* component is a factory
+
+ This design pattern is optional, but recommended. Component factories are react-stamp's solution for avoiding the often hard to debug problems created by multiple instances of React. Read more about that [here](https://medium.com/@dan_abramov/two-weird-tricks-that-fix-react-7cf9bbdef375). By injecting the React library, we are able to guarantee the version and instance of React that a component will receive.
+
+* caching
+
+ This goes hand in hand with designing components as factories. Node.js's internal caching will not work as expected for component factories, react-stamp's cache utility can be used as a replacement.
+
 ### Class decorator
 
 For all those nice guys/gals that like `class` and just want some mixability. It is assumed that the component directly extends React.Component, anything else should be inherited via stamp composition.
@@ -54,3 +137,4 @@ assert.deepEqual(
 ```
 
 __*Warning: Class decorators are a proposal for ES7, they are not set in stone.*__
+

--- a/test/factoryExample.js
+++ b/test/factoryExample.js
@@ -1,0 +1,58 @@
+import React from 'react/addons';
+import reactStamp from '../src';
+import test from 'tape';
+import { cache } from '../src/utils';
+
+const TestUtils = React.addons.TestUtils;
+const shallowRenderer = TestUtils.createRenderer();
+
+const mixin1 = {
+  componentWillMount() {
+    this.state.mixin1 = true;
+  },
+};
+
+const mixin2 = {
+  componentWillMount() {
+    this.state.mixin2 = true;
+  },
+};
+
+const id = cache.uniqueId();
+const componentFactory = React => {
+  return cache.find(id) || cache.save(
+    reactStamp(React, {
+      state: {
+        comp: false,
+        mixin1: false,
+        mixin2: false,
+      },
+
+      _onClick() {
+        return this.state;
+      },
+
+      componentWillMount() {
+        this.state.comp = true;
+      },
+
+      render() {
+        return <input type='button' onClick={() => this._onClick()} />;
+      },
+    }), id
+  );
+};
+
+const ComposedComp = componentFactory(React).compose(mixin1, mixin2);
+
+shallowRenderer.render(<ComposedComp />);
+const button = shallowRenderer.getRenderOutput();
+
+test('factory example', (t) => {
+  t.plan(1);
+
+  t.deepEqual(
+    button.props.onClick(), { comp: true, mixin1: true, mixin2: true },
+    'should return component state with all truthy props'
+  );
+});

--- a/test/index.js
+++ b/test/index.js
@@ -5,3 +5,5 @@ import './methods';
 import './compose';
 import './wrapMethods';
 import './advanced';
+import './readmeExample';
+import './factoryExample';

--- a/test/readmeExample.js
+++ b/test/readmeExample.js
@@ -1,0 +1,53 @@
+import React from 'react/addons';
+import reactStamp from '../src';
+import test from 'tape';
+
+const TestUtils = React.addons.TestUtils;
+const shallowRenderer = TestUtils.createRenderer();
+
+const mixin1 = {
+  componentWillMount() {
+    this.state.mixin1 = true;
+  },
+};
+
+const mixin2 = {
+  componentWillMount() {
+    this.state.mixin2 = true;
+  },
+};
+
+const Component = reactStamp(React, {
+  state: {
+    comp: false,
+    mixin1: false,
+    mixin2: false,
+  },
+
+  _onClick() {
+    return this.state;
+  },
+
+  componentWillMount() {
+    this.state.comp = true;
+  },
+
+  render() {
+    return <input type='button' onClick={() => this._onClick()} />;
+  },
+});
+
+const ComposedComp = Component.compose(mixin1, mixin2);
+
+shallowRenderer.render(<ComposedComp />);
+const button = shallowRenderer.getRenderOutput();
+
+test('readme example', (t) => {
+  t.plan(1);
+
+  t.deepEqual(
+    button.props.onClick(), { comp: true, mixin1: true, mixin2: true },
+    'should return component state with all truthy props'
+  );
+});
+


### PR DESCRIPTION
I don't think most people will want to create components as factories. The README example should demonstrate a common use case. The factory example can be included in the advanced docs.