### PR TITLE
Override instead of throw for select React methods

### DIFF
--- a/docs/composition.md
+++ b/docs/composition.md
@@ -1,121 +1,34 @@
 ## Composition logic
 
-Component composition might be compared to `React.createClass`'s mixin feature. A significant difference is that you compose a component without referencing the mixins being inherited from inside the component's declaration.
+Component composition might be compared to `React.createClass`'s mixin feature. A significant difference is that react-stamp decouples the relationship between component and mixin.
 
 
 ### State
-Composed components inherit other components' state.
+Component state is deep merged.
 
-```js
-const mixin = {
-  state: {
-    foo: true,
-    bar: true,
-  },
-};
-
-const component = reactStamp(React).compose(mixin);
-```
-
-```js
-assert.deepEqual(
-  component().state, { foo: true, bar: true },
-  'should inherit state'
-);
-  >> ok
-```
+**TODO: Example**
 
 __*`React.createClass` throws an Invariant Violation when duplicate keys are found in `getInitialState`. `react-stamp` merges duplicate keys.*__
 
 ### Statics
-Composed components inherit other components' statics.
+Component statics are deep merged.
 
-```js
-const mixin = {
-  statics: {
-    someStatic: {
-      bar: true,
-    },
-  },
-
-  propTypes: {
-    bar: React.PropTypes.string,
-  },
-};
-
-const component = reactStamp(React, {
-  statics: {
-    someStatic: {
-      foo: true,
-    },
-  },
-
-  propTypes: {
-    foo: React.PropTypes.string,
-  },
-}).compose(mixin);
-```
-
-```js
-assert.ok(
-  component.propTypes.bar,
-  'should inherit bar propType'
-);
-  >> ok
-assert.ok(
-  component.propTypes.foo,
-  'should inherit foo propType'
-);
-  >> ok
-assert.deepEqual(
-  component.someStatic, { foo: true, bar: true },
-  'should merge non-React statics'
-);
-  >> ok
-```
+**TODO: Example**
 
 __*`React.createClass` throws an Invariant Violation when duplicate keys are found in `propTypes` and `getDefaultProps`. `react-stamp` merges duplicate keys.*__
 
 ### Methods
-Composed components inherit other components' methods. A handful of React lifecycle methods get 'wrapped' executing with first-in priority. All other methods override with last-in priority.
+Component methods are either wrapped or overridden. React lifecycle methods, with the exception of `render`, get wrapped executing with first-in priority. All other methods override with last-in priority.
 
-__Wrapped__
+* `componentDidMount` - wrapped and ran sequentially
+* `componentDidUpdate` - wrapped and ran sequentially
+* `componentWillMount` - wrapped and ran sequentially
+* `componentWillReceiveProps` - wrapped and ran sequentially
+* `componentWillUnmount` - wrapped and ran sequentially
+* `componentWillUpdate` - wrapped and ran sequentially
+* `getChildContext` - wrapped and ran sequentially with results merged
+* `shouldComponentUpdate` - wrapped and ran sequentially with results OR'd
 
-* componentWillMount
-* componentDidMount
-* componentWillReceiveProps
-* componentWillUpdate
-* componentDidUpdate
-* componentWillUnmount
-* getChildContext
+**TODO: Example**
 
-```js
-const mixin = {
-  componentDidMount() {
-    this.state.mixin = true;
-  },
-};
-
-const component = reactStamp(React, {
-  state: {
-    component: false,
-    mixin: false,
-  },
-
-  componentDidMount() {
-    this.state.component = true;
-  }
-}).compose(mixin);
-
-const instance = component();
-instance.componentDidMount();
-```
-
-```js
-assert.deepEqual(
-  instance.state, { component: true, mixin: true },
-  'should inherit functionality of mixable methods'
-);
-  >> ok
-```
-__*`React.createClass` throws an Invariant Violation when duplicate `shouldComponentUpdate` or `render` methods exist, `react-stamp` overrides with last-in priority.*__
+__*`React.createClass` throws an Invariant Violation when duplicate `shouldComponentUpdate` or `render` methods exist. `react-stamp` ORs the results of `shouldComponentUpdate` and overrides `render` with last-in priority.*__

--- a/docs/composition.md
+++ b/docs/composition.md
@@ -25,7 +25,7 @@ assert.deepEqual(
   >> ok
 ```
 
-__*`React.createClass` throws an Invariant Violation when duplicate keys are found within mixins. `react-stamp` will merge duplicate keys.
+__*`React.createClass` throws an Invariant Violation when duplicate keys are found in `getInitialState`. `react-stamp` merges duplicate keys.*__
 
 ### Statics
 Composed components inherit other components' statics.
@@ -74,10 +74,10 @@ assert.deepEqual(
   >> ok
 ```
 
-__*`React.createClass` throws an Invariant Violation when duplicate keys are found in `getDefaultProps` and `getInitialState`. `react-stamp` will merge duplicate keys.*__
+__*`React.createClass` throws an Invariant Violation when duplicate keys are found in `propTypes` and `getDefaultProps`. `react-stamp` merges duplicate keys.*__
 
 ### Methods
-Composed components inherit other components' methods. A handful of React methods will be 'wrapped' executing with first-in priority. React methods with a unique constraint will throw on duplicates. Non-React methods will override with last-in priority.
+Composed components inherit other components' methods. A handful of React lifecycle methods get 'wrapped' executing with first-in priority. All other methods override with last-in priority.
 
 __Wrapped__
 
@@ -88,11 +88,6 @@ __Wrapped__
 * componentDidUpdate
 * componentWillUnmount
 * getChildContext
-
-__Unique__
-
-* shouldComponentUpdate
-* render
 
 ```js
 const mixin = {
@@ -123,4 +118,4 @@ assert.deepEqual(
 );
   >> ok
 ```
-__*`React.createClass` throws an Invariant Violation when duplicate `shouldComponentUpdate` or `render` methods exist, `react-stamp` will throw a TypeError.*__
+__*`React.createClass` throws an Invariant Violation when duplicate `shouldComponentUpdate` or `render` methods exist, `react-stamp` overrides with last-in priority.*__

--- a/src/index.js
+++ b/src/index.js
@@ -4,7 +4,6 @@ import {
   compose,
   getReactDescriptor,
   parseDesc,
-  dupeFilter,
 } from './utils';
 
 /**
@@ -20,14 +19,12 @@ export default function reactStamp(React, desc = {}) {
   const specDesc = parseDesc(desc);
   const { methods, initializers } = getReactDescriptor(React && React.Component);
 
-  // Do not override React's `setState` and `forceUpdate` methods.
-  methods && (specDesc.methods =
-              assign({}, methods, specDesc.methods, dupeFilter));
-  initializers && (specDesc.initializers =
-                   initializers.concat(specDesc.initializers || []));
+  if (initializers) {
+    specDesc.initializers = initializers.concat(specDesc.initializers || []);
+  }
 
   const stamp = (options, ...args) => {
-    let instance = Object.create(specDesc.methods || {});
+    let instance = Object.create(assign({}, methods, specDesc.methods));
 
     assign(instance,
       specDesc.deepProperties, specDesc.properties,

--- a/src/utils/compose.js
+++ b/src/utils/compose.js
@@ -38,7 +38,7 @@ export default function compose(...args) {
       staticPropertyDescriptors, deepProperties, deepStaticProperties, configuration,
     } = desc;
 
-    // React spec
+    // Wrap React lifecycle methods
     compDesc.methods = wrapMethods(compDesc.methods, methods);
 
     // Stamp spec

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -2,7 +2,7 @@ import * as cache from './cache';
 import compose from './compose';
 import stamp from './decorator';
 import { getReactDescriptor, parseDesc } from './descriptor';
-import { dupeFilter, wrapMethods } from './react';
+import wrapMethods from './react';
 import { isSpecDescriptor } from './type';
 
 export {
@@ -11,7 +11,6 @@ export {
   stamp,
   getReactDescriptor,
   parseDesc,
-  dupeFilter,
   wrapMethods,
   isSpecDescriptor,
 };

--- a/src/utils/react.js
+++ b/src/utils/react.js
@@ -2,9 +2,9 @@ import assign from 'lodash/object/assign';
 import mapValues from 'lodash/object/mapValues';
 
 /**
- * React specification for creating new components
+ * React lifecycle methods
  */
-const reactSpec = {
+const lifecycle = {
   componentDidMount: 'wrap',
   componentDidUpdate: 'wrap',
   componentWillMount: 'wrap',
@@ -13,12 +13,12 @@ const reactSpec = {
   componentWillUpdate: 'wrap',
   getChildContext: 'wrap_merge',
   render: 'override',
-  shouldComponentUpdate: 'override',
+  shouldComponentUpdate: 'wrap_or',
 };
 
 /**
  * Iterate through object methods, creating wrapper
- * functions for mixable React methods, starting
+ * functions for React lifecycle methods, starting
  * execution with first-in.
  *
  * @param  {Object} targ The target object.
@@ -28,7 +28,7 @@ const reactSpec = {
  */
 export default function wrapMethods(targ = {}, src = {}) {
   const methods = mapValues(src, (val, key) => {
-    switch (reactSpec[key]) {
+    switch (lifecycle[key]) {
       case 'wrap':
         return function () {
           targ[key] && targ[key].apply(this, arguments);
@@ -41,6 +41,13 @@ export default function wrapMethods(targ = {}, src = {}) {
 
           return res1 ? assign(res1, res2) : res2;
         };
+      case 'wrap_or':
+        return function () {
+          const res1 = targ[key] && targ[key].apply(this, arguments);
+          const res2 = val.apply(this, arguments);
+
+          return res1 || res2;
+        }
       case 'override':
       default:
         return val;

--- a/test/compose.js
+++ b/test/compose.js
@@ -237,19 +237,23 @@ test('stamps composed of stamps with wrapable methods', (t) => {
   );
 });
 
-test('stamps composed of stamps with non-mixable methods', (t) => {
+test('stamps composed of stamps with non-wrapable methods', (t) => {
   t.plan(1);
 
   const mixin = reactStamp(null, {
-    render() {},
+    render() {
+      return true
+    },
   });
 
   const stamp = reactStamp(React, {
-    render() {},
+    render() {
+      return false
+    },
   });
 
-  t.throws(
-    () => stamp.compose(mixin), TypeError,
-    'should throw on duplicate methods'
+  t.ok(
+    stamp.compose(mixin)().render(),
+    'should override with last-in priority'
   );
 });

--- a/test/wrapMethods.js
+++ b/test/wrapMethods.js
@@ -11,8 +11,8 @@ const methods = {
   componentWillUnmount: 'wrap',
   componentWillUpdate: 'wrap',
   getChildContext: 'wrap_merge',
+  shouldComponentUpdate: 'wrap_or',
   render: 'override',
-  shouldComponentUpdate: 'override',
   nonReactMethod: 'override',
 };
 
@@ -22,6 +22,9 @@ forEach(methods, (type, method) => {
   if (type === 'wrap_merge') {
     targ[method] = () => ({ foo: true, bar: false });
     src[method] = () => ({ bar: true });
+  } else if (type == 'wrap_or') {
+    targ[method] = () => false;
+    src[method] = () => true;
   } else {
     targ[method] = function() {
       this.result = [ 'foo' ];
@@ -47,17 +50,22 @@ test('wrapMethods(targ, src)', (t) => {
         obj.result, [ 'foo', 'bar' ],
         `should wrap '${method}'`
       );
+    } else if (type === 'wrap_merge') {
+      t.deepEqual(
+        obj[method](), { foo: true, bar: true },
+        `should wrap and merge '${method}'`
+      );
+    } else if (type === 'wrap_or') {
+      t.ok(
+        obj[method](),
+        `should wrap and OR '${method}'`
+      );
     } else if (type === 'override') {
       obj[method]();
 
       t.deepEqual(
         obj.result, [ 'bar' ],
         `should override '${method}'`
-      );
-    } else if (type === 'wrap_merge') {
-      t.deepEqual(
-        obj[method](), { foo: true, bar: true },
-        `should wrap and merge '${method}'`
       );
     }
   });


### PR DESCRIPTION
I feel throwing on duplicate `render` and `shouldComponentUpdate` methods is unnecessary and takes away from the the power of stamp composition. Instead, we can just override with last-in priority. This would simplify the React logic quite a bit, leaving only the React lifecycle method wrapping.

I don't consider this unexpected behavior, if anything it adds flexibility. Thoughts @ericelliott?